### PR TITLE
Feature/load instance bug

### DIFF
--- a/src/components/project-execution/CreateExecutionLoadInstance.vue
+++ b/src/components/project-execution/CreateExecutionLoadInstance.vue
@@ -33,6 +33,10 @@ export default {
       type: File,
       default: null,
     },
+    existingInstanceErrors: {
+      type: String,
+      default: null,
+    }
   },
   created() {
     this.showSnackbar = inject('showSnackbar')
@@ -41,7 +45,7 @@ export default {
     return {
       selectedFile: null,
       selectedInstance: null,
-      instanceErrors: null,
+      instanceErrors: this.existingInstanceErrors,
       store: useGeneralStore(),
       showSnackbar: null,
     }
@@ -53,6 +57,12 @@ export default {
       },
       immediate: true,
     },
+    existingInstanceErrors: {
+      handler(newErrors) {
+        this.instanceErrors = newErrors
+      },
+      immediate: true
+    }
   },
   methods: {
     onFileSelected(file) {
@@ -117,6 +127,7 @@ export default {
           this.instanceErrors = errors
             .map((error) => `<li>${error.instancePath} - ${error.message}</li>`)
             .join('')
+            this.$emit('update:exisistingInstanceErrors', this.instanceErrors)
           throw new Error(
             this.$t(
               'projectExecution.steps.step3.loadInstance.instanceSchemaError',
@@ -128,6 +139,7 @@ export default {
         this.selectedInstance = instance
         this.$emit('instance-selected', this.selectedInstance)
         this.instanceErrors = null
+        this.$emit('update:existingInstanceErrors', this.instanceErrors)
         this.showSnackbar(
           this.$t('projectExecution.steps.step3.loadInstance.instanceLoaded'),
         )
@@ -140,6 +152,7 @@ export default {
             : this.$t(
                 'projectExecution.steps.step3.loadInstance.unexpectedError',
               )
+        this.$emit('update:existingInstanceErrors', this.instanceErrors)
         this.showSnackbar(error, 'error')
         throw new Error(error.message)
       }

--- a/src/components/project-execution/CreateExecutionLoadInstance.vue
+++ b/src/components/project-execution/CreateExecutionLoadInstance.vue
@@ -54,18 +54,27 @@ export default {
     fileSelected: {
       handler(newFile) {
         this.selectedFile = newFile
+        console.log('fileSelected changed:', newFile);
       },
       immediate: true,
     },
     existingInstanceErrors: {
       handler(newErrors) {
         this.instanceErrors = newErrors
+        console.log('existingInstanceErrors changed:', newErrors);
       },
       immediate: true
     }
   },
   methods: {
     onFileSelected(file) {
+
+      // Reset states before processing the new file
+      this.selectedFile = null
+      this.selectedInstance = null
+      this.instanceErrors = null
+      this.$emit('update:existingInstanceErrors', this.instanceErrors)
+      
       this.selectedFile = file
 
       const extension = file.name.split('.').pop()

--- a/src/views/ProjectExecutionView.vue
+++ b/src/views/ProjectExecutionView.vue
@@ -58,8 +58,10 @@
           <CreateExecutionLoadInstance
             :fileSelected="instanceFile"
             :newExecution="newExecution"
+            :existingInstanceErrors="existingInstanceErrors"
             @fileSelected="handleInstanceFileSelected"
             @instanceSelected="handleInstanceSelected"
+            @update:existingInstanceErrors="existingInstanceErrors = $event"
             class="mt-4"
           >
           </CreateExecutionLoadInstance>

--- a/src/views/ProjectExecutionView.vue
+++ b/src/views/ProjectExecutionView.vue
@@ -184,6 +184,7 @@ export default {
         name: null,
         description: null,
       },
+      existingInstanceErrors: null,
     }
   },
   created() {
@@ -302,7 +303,7 @@ export default {
           !this.newExecution.name) ||
         (this.currentStep === 2 &&
           this.optionSelected === 'createExecution' &&
-          !this.newExecution.instance) ||
+          (!this.newExecution.instance || this.existingInstanceErrors)) ||
         (this.currentStep === 4 &&
           this.optionSelected === 'createExecution' &&
           !this.newExecution.selectedSolver) ||


### PR DESCRIPTION
After fixing the bug regarding going onwards and backwards, and errors were not showing properly (when the instance had errors), now another bug has been fixed.
When uploading an instance, and in the same step, the instance was changed, the errors from the instance that didn't comply with the schema, weren't being saved. That was fixed.
Also, the button was not disabled when there were errors in the instance. This was also fixed.