### PR TITLE
Feature/execution polling hardening

### DIFF
--- a/src/components/project-execution/ProjectExecutionsTable.vue
+++ b/src/components/project-execution/ProjectExecutionsTable.vue
@@ -237,14 +237,23 @@
 
             <!-- Delete execution -->
             <span>
-              <v-icon size="small" @click="deleteExecution(item)">
-                mdi-delete
-              </v-icon>
-              <v-tooltip activator="parent" location="bottom">
-                <span>
-                  {{ t('executionTable.deleteExecution') }}
-                </span>
-              </v-tooltip>
+              <template v-if="!deletingExecutions.has(item.id)">
+                <v-icon size="small" @click="deleteExecution(item)">
+                  mdi-delete
+                </v-icon>
+                <v-tooltip activator="parent" location="bottom">
+                  <span>
+                    {{ t('executionTable.deleteExecution') }}
+                  </span>
+                </v-tooltip>
+              </template>
+              <v-progress-circular
+                v-else
+                indeterminate
+                size="20"
+                width="2"
+                color="primary"
+              ></v-progress-circular>
             </span>
           </span>
         </template>
@@ -346,6 +355,10 @@ const props = defineProps({
     default: true,
   },
   loadingExecutions: {
+    type: Set,
+    default: () => new Set(),
+  },
+  deletingExecutions: {
     type: Set,
     default: () => new Set(),
   },

--- a/src/plugins/locales/en.ts
+++ b/src/plugins/locales/en.ts
@@ -63,6 +63,8 @@ export default {
       errorDelete: 'An error occurred while deleting the execution',
       successLoad: 'Execution loaded successfully',
       errorLoad: 'An error occurred while loading the execution',
+      autoLoadError:
+        'An unexpected error occurred while retrieving the execution information',
     },
     exitConfirmation: {
       title: 'Exit creation process',

--- a/src/plugins/locales/es.ts
+++ b/src/plugins/locales/es.ts
@@ -65,6 +65,8 @@ export default {
       errorDelete: 'Ocurrió un error al eliminar la ejecución',
       successLoad: 'Ejecución cargada con éxito',
       errorLoad: 'Ocurrió un error al cargar la ejecución',
+      autoLoadError:
+        'Ocurrió un error inesperado al recuperar la información de la ejecución',
     },
     exitConfirmation: {
       title: 'Salir del proceso de creación',

--- a/src/plugins/locales/fr.ts
+++ b/src/plugins/locales/fr.ts
@@ -59,6 +59,8 @@ export default {
         "Une erreur est survenue lors de la suppression de l'exécution",
       successLoad: 'Exécution chargée avec succès',
       errorLoad: "Une erreur est survenue lors du chargement de l'exécution",
+      autoLoadError:
+        "Une erreur inattendue est survenue lors de la récupération des informations de l'exécution",
     },
     steps: {
       step1: {

--- a/src/repositories/ExecutionRepository.ts
+++ b/src/repositories/ExecutionRepository.ts
@@ -191,7 +191,11 @@ export default class ExecutionRepository {
       const exec = response.content
       return { state: exec.state, id: exec.id }
     }
-    return null
+    // The API client only throws on 401 (see Api.ts); for 403/503/5xx it
+    // resolves with a non-200 status. Throw here so the polling loop in
+    // `autoLoadExecutions` can stop retrying instead of hammering a failing
+    // endpoint every few seconds.
+    throw new Error(`Error getting execution state (HTTP ${response.status})`)
   }
 
   // Get full execution data by id
@@ -200,6 +204,12 @@ export default class ExecutionRepository {
 
     if (response.status === 200) {
       const execution = response.content
+      // Guard against a partial/corrupted response (seen with HTTP2 stream
+      // errors): without instance_id we would otherwise fire a doomed request
+      // to `/instance/undefined/data/`.
+      if (!execution.instance_id) {
+        throw new Error('Execution response is missing instance_id')
+      }
       const instanceRepository = new InstanceRepository()
       const instance = await instanceRepository.getInstance(
         execution.instance_id,

--- a/src/stores/general.ts
+++ b/src/stores/general.ts
@@ -1,4 +1,4 @@
-import { defineStore } from 'pinia'
+import { defineStore, acceptHMRUpdate } from 'pinia'
 import { markRaw } from 'vue'
 import session from '@cornflow-ui/core/services/AuthService'
 import appConfig from '@/app/config'
@@ -86,6 +86,12 @@ function buildNonEmptyChecksMap(dataChecks: any): Record<string, any[]> {
 
 const HISTORICAL_POLL_MS = 4000
 let historicalPollTimer: ReturnType<typeof setTimeout> | null = null
+
+// Module-scoped mirror of the store's auto-load interval so it can be cleared
+// on hot-module replacement (see the `import.meta.hot` block at the bottom).
+// Without this, Vite HMR leaves the previous module's `setInterval` running
+// during development, stacking up zombie pollers that flood the backend.
+let autoLoadPollTimer: ReturnType<typeof setInterval> | null = null
 
 function clearHistoricalPollTimer() {
   if (historicalPollTimer) {
@@ -724,6 +730,7 @@ export const useGeneralStore = defineStore('general', {
           this.autoLoadTickInFlight = false
         }
       }, 4000) // Check every 4 seconds
+      autoLoadPollTimer = this.autoLoadInterval
     },
 
     /**
@@ -785,6 +792,7 @@ export const useGeneralStore = defineStore('general', {
         clearInterval(this.autoLoadInterval)
         this.autoLoadInterval = null
       }
+      autoLoadPollTimer = null
     },
 
     removeLoadedExecution(index: number) {
@@ -963,3 +971,17 @@ export const useGeneralStore = defineStore('general', {
     },
   },
 })
+
+// During development, Vite hot-reloads this module on every edit but does not
+// stop timers started by the previous instance. Clear all background pollers on
+// dispose so they don't pile up into zombie intervals hammering the backend.
+if (import.meta.hot) {
+  import.meta.hot.dispose(() => {
+    clearHistoricalPollTimer()
+    if (autoLoadPollTimer) {
+      clearInterval(autoLoadPollTimer)
+      autoLoadPollTimer = null
+    }
+  })
+  import.meta.hot.accept(acceptHMRUpdate(useGeneralStore, import.meta.hot))
+}

--- a/src/stores/general.ts
+++ b/src/stores/general.ts
@@ -33,6 +33,7 @@ import {
 } from '@cornflow-ui/core/types/frontendAutomation'
 import { TableSchema } from '@cornflow-ui/core/config/views'
 import { i18n, locale } from '@cornflow-ui/core/plugins/i18n'
+import { showSnackbar } from '@cornflow-ui/core/services/SnackbarService'
 import {
   resolveTableConfigTitles,
   getExecutionConfigFromSchemaConfig,
@@ -125,6 +126,8 @@ export const useGeneralStore = defineStore('general', {
     loadedExecutions: [] as LoadedExecution[],
     selectedExecution: null,
     autoLoadInterval: null,
+    /** Guards against overlapping auto-load ticks when a poll is still in flight. */
+    autoLoadTickInFlight: false,
     isDrawerPinned: false, // New state for drawer pin status
     uploadComponentKey: 0,
     tabBarKey: 0,
@@ -693,9 +696,7 @@ export const useGeneralStore = defineStore('general', {
 
     async autoLoadExecutions() {
       // Clear any existing interval
-      if (this.autoLoadInterval) {
-        clearInterval(this.autoLoadInterval)
-      }
+      this.stopAutoLoadExecutions()
 
       // Start a new interval. We poll only execution **state** (a few bytes)
       // via the lightweight `getExecutionState` endpoint, and only re-fetch
@@ -704,9 +705,23 @@ export const useGeneralStore = defineStore('general', {
       // the full `/data/` + instance for each still-running execution,
       // which for 500k-row instances meant several MB downloaded every 4s.
       this.autoLoadInterval = setInterval(async () => {
-        for (const execution of this.loadedExecutions) {
-          if (execution.state !== 0 && execution.state !== -7) continue
-          await this.refreshRunningExecution(execution)
+        // Prevent overlapping ticks. The callback is async, so if the previous
+        // tick is still awaiting slow or failing requests (e.g. a CORS/network
+        // failure that takes a while to reject), setInterval would fire another
+        // tick anyway and they would stack up into a flood of parallel calls.
+        // Skip while one is already running.
+        if (this.autoLoadTickInFlight) return
+        this.autoLoadTickInFlight = true
+        try {
+          for (const execution of this.loadedExecutions) {
+            if (execution.state !== 0 && execution.state !== -7) continue
+            // A hard failure of the poll itself (backend down/unavailable)
+            // stops the loop instead of hammering a failing endpoint every 4s.
+            const keepPolling = await this.refreshRunningExecution(execution)
+            if (!keepPolling) return
+          }
+        } finally {
+          this.autoLoadTickInFlight = false
         }
       }, 4000) // Check every 4 seconds
     },
@@ -715,22 +730,25 @@ export const useGeneralStore = defineStore('general', {
      * Polls a single running execution's lightweight state and, only when it
      * transitions out of the running set, re-fetches and stores the full
      * payload. Extracted from `autoLoadExecutions` to keep nesting/complexity
-     * low; errors are swallowed (logged) so one failure can't stop the loop.
+     * low. Returns `true` to keep polling, or `false` on a hard failure of the
+     * poll itself (backend down/unavailable) so the caller stops the interval.
      */
-    async refreshRunningExecution(execution: LoadedExecution) {
+    async refreshRunningExecution(
+      execution: LoadedExecution,
+    ): Promise<boolean> {
       try {
         const meta = await this.executionRepository.getExecutionState(
           execution.executionId,
         )
-        if (!meta) return
+        if (!meta) return true
         // Still running → keep polling, nothing to update yet.
-        if (meta.state === 0 || meta.state === -7) return
+        if (meta.state === 0 || meta.state === -7) return true
 
         // State transitioned: now (and only now) fetch the full payload.
         const updatedExecution = await this.executionRepository.loadExecution(
           execution.executionId,
         )
-        if (!updatedExecution) return
+        if (!updatedExecution) return true
 
         this.addLoadedExecution(updatedExecution)
 
@@ -740,8 +758,32 @@ export const useGeneralStore = defineStore('general', {
         ) {
           this.selectedExecution = updatedExecution
         }
+        return true
       } catch (error) {
+        // A hard failure of the poll itself (timeout, 502/503, network, invalid
+        // token) means the backend is down/unavailable — stop polling instead
+        // of hammering it (which also feeds the invalid-token cascade after a
+        // restart) and let the user know. (401 is already handled by the API
+        // client, which clears the session and redirects, so we skip it here.)
         console.error('Error auto-loading execution', error)
+        this.stopAutoLoadExecutions()
+        const message = error instanceof Error ? error.message : String(error)
+        if (!message.includes('Unauthorized')) {
+          showSnackbar(
+            i18n.global.t('projectExecution.snackbar.autoLoadError'),
+            'error',
+          )
+        }
+        return false
+      }
+    },
+
+    /** Stops the background execution-state polling interval, if running. */
+    stopAutoLoadExecutions() {
+      this.autoLoadTickInFlight = false
+      if (this.autoLoadInterval) {
+        clearInterval(this.autoLoadInterval)
+        this.autoLoadInterval = null
       }
     },
 

--- a/src/views/HistoryExecutionView.vue
+++ b/src/views/HistoryExecutionView.vue
@@ -54,6 +54,7 @@
             :formatDateByTime="true"
             :useFixedWidth="true"
             :loadingExecutions="loadingExecutions"
+            :deletingExecutions="deletingExecutions"
             @loadExecution="loadExecution"
             @deleteExecution="deleteExecution"
           ></ProjectExecutionsTable>
@@ -116,6 +117,10 @@ export default {
       },
       showSnackbar: null,
       loadingExecutions: new Set(),
+      deletingExecutions: new Set(),
+      // Coalesce overlapping list fetches (see `fetchData`).
+      fetchInFlight: false,
+      fetchQueued: false,
       hideReplanned: false,
       // Start `true` so the spinner is visible from the very first paint,
       // before `activated()` fires `fetchData`. Avoids the flash where
@@ -131,6 +136,11 @@ export default {
   },
   activated() {
     this.fetchData()
+    // Make sure the background poller is running so rows that are still loading
+    // flip to their final state while the user watches the history — even if
+    // the list request itself is failing. `loadedExecutionsSignature` then
+    // syncs those state changes into the table.
+    this.generalStore.autoLoadExecutions()
   },
   computed: {
     title() {
@@ -198,8 +208,26 @@ export default {
         },
       ]
     },
+    /**
+     * Signature of the store's tracked executions (id + state). Changes only
+     * when an execution transitions state (the background poller updates
+     * `loadedExecutions` on transition), which is exactly when the history
+     * table needs to refresh its status chips.
+     */
+    loadedExecutionsSignature() {
+      return this.generalStore.loadedExecutions
+        .map((execution) => `${execution.executionId}:${execution.state}`)
+        .join('|')
+    },
   },
   watch: {
+    // Keep the history rows in sync with the live execution state held in the
+    // store. Without this, a row launched while the user is on this view stays
+    // stuck on "Loading" forever: the table is a one-shot snapshot from
+    // `fetchData`, while the actual completion is detected by the store poller.
+    loadedExecutionsSignature() {
+      this.syncExecutionStatesFromStore()
+    },
     dateOptionSelected(newVal, oldVal) {
       const today = new Date()
       const yesterday = new Date(today)
@@ -278,6 +306,22 @@ export default {
       }
     },
     async fetchData(attempt = 0) {
+      // Coalesce overlapping fetches. A single user action (picking a date
+      // option, typing custom dates) can fire several watchers, and each list
+      // query can be slow/heavy on the backend. Keep at most one request in
+      // flight plus one trailing refetch (with the latest dates) so we don't
+      // pile duplicate queries onto a backend that is already struggling while
+      // an execution is running.
+      if (attempt === 0) {
+        if (this.fetchInFlight) {
+          this.fetchQueued = true
+          return
+        }
+        this.fetchInFlight = true
+        // Show the "loading" state (not the previous rows) until the new data
+        // actually arrives.
+        this.data = []
+      }
       this.loadingData = true
       try {
         const result = await this.generalStore.fetchExecutionsByDateRange(
@@ -288,6 +332,10 @@ export default {
         if (result) {
           this.showSnackbar(this.$t('projectExecution.snackbar.succesSearch'))
           this.data = this.formatData(result)
+          // Overlay the freshest known state from the store so rows reflect any
+          // execution that has already finished/transitioned since the list was
+          // built on the backend.
+          this.syncExecutionStatesFromStore()
           return
         }
 
@@ -300,7 +348,7 @@ export default {
         // the token should be in place and the call succeeds transparently.
         if (attempt === 0) {
           await new Promise((resolve) => setTimeout(resolve, 600))
-          return this.fetchData(1)
+          return await this.fetchData(1)
         }
 
         this.data = this.formatData([])
@@ -313,6 +361,52 @@ export default {
         )
       } finally {
         this.loadingData = false
+        if (attempt === 0) {
+          this.fetchInFlight = false
+          // If a fetch was requested while this one ran, run it once now with
+          // whatever the current dates are.
+          if (this.fetchQueued) {
+            this.fetchQueued = false
+            this.fetchData()
+          }
+        }
+      }
+    },
+    /**
+     * Updates the state of the displayed rows from the store's tracked
+     * executions. The background poller keeps `loadedExecutions` current, so a
+     * row that was "Loading" when fetched flips to its final state here without
+     * needing another (possibly queued/stalled) list request.
+     */
+    syncExecutionStatesFromStore() {
+      const stateById = new Map(
+        this.generalStore.loadedExecutions.map((execution) => [
+          execution.executionId,
+          execution.state,
+        ]),
+      )
+      this.applyExecutionStates(stateById)
+    },
+    /**
+     * Applies a map of executionId -> state onto the displayed rows. Reassigns
+     * `this.data` with fresh references only when something actually changed,
+     * so the table re-renders the status chips (and we avoid needless churn).
+     */
+    applyExecutionStates(stateById) {
+      let changed = false
+      const next = this.data.map((group) => ({
+        ...group,
+        data: group.data.map((item) => {
+          const nextState = stateById.get(item.id)
+          if (nextState !== undefined && nextState !== item.state) {
+            changed = true
+            return { ...item, state: nextState }
+          }
+          return item
+        }),
+      }))
+      if (changed) {
+        this.data = next
       }
     },
     formatData(rawData) {
@@ -386,6 +480,9 @@ export default {
       }
     },
     async deleteExecution(execution) {
+      // Mark the row as deleting so its action shows a spinner instead of the
+      // trash icon while the (sometimes slow) DELETE + refetch is in flight.
+      this.deletingExecutions.add(execution.id)
       try {
         const result = await this.generalStore.deleteExecution(execution.id)
 
@@ -403,6 +500,8 @@ export default {
           this.$t('projectExecution.snackbar.errorDelete'),
           'error',
         )
+      } finally {
+        this.deletingExecutions.delete(execution.id)
       }
     },
   },

--- a/tests/unit/core/stores/general.spec.ts
+++ b/tests/unit/core/stores/general.spec.ts
@@ -92,6 +92,12 @@ vi.mock('@cornflow-ui/core/plugins/i18n', () => ({
       locale: { value: 'en' },
     },
   },
+  i18n: {
+    global: {
+      locale: { value: 'en' },
+      t: (key: string) => key,
+    },
+  },
   locale: { value: 'en' },
 }))
 
@@ -1448,20 +1454,27 @@ describe('General Store', () => {
       expect(store.selectedExecution).toEqual(updated)
     })
 
-    test('swallows errors', async () => {
+    test('stops polling and notifies on a hard poll failure', async () => {
       const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
       const store = useGeneralStore()
       const execRepo = {
         getExecutionState: vi.fn().mockRejectedValue(new Error('state-fail')),
       }
       store.executionRepository = execRepo as any
+      const stopSpy = vi
+        .spyOn(store, 'stopAutoLoadExecutions')
+        .mockImplementation(() => {})
 
-      await store.refreshRunningExecution({
+      const result = await store.refreshRunningExecution({
         executionId: 'r1',
         state: 0,
       } as LoadedExecution)
 
+      // New contract: a failed poll returns false so the caller stops the
+      // interval, logs the error, and stops the background poller.
+      expect(result).toBe(false)
       expect(consoleSpy).toHaveBeenCalled()
+      expect(stopSpy).toHaveBeenCalled()
       consoleSpy.mockRestore()
     })
   })


### PR DESCRIPTION
## Changes

### Polling hardening
- `ExecutionRepository.getExecutionState` now **throws** on non-200 (403/503/5xx) so the poll loop can stop instead of retrying a failing endpoint every few seconds.
- `ExecutionRepository.loadExecution` guards against a response missing `instance_id` (seen with HTTP2 stream corruption) that would otherwise fire `/instance/undefined/data/`.
- `general.autoLoadExecutions`: skips overlapping ticks (`autoLoadTickInFlight`) and **stops** the interval on a hard poll failure, showing a snackbar (401 is left to the API client). Adapted to core's extracted `refreshRunningExecution`, which now returns a boolean to signal "keep polling".
- New `stopAutoLoadExecutions()` helper and `projectExecution.snackbar.autoLoadError` locale (en/es/fr).

### History UX + HMR
- `ProjectExecutionsTable`: per-row delete spinner via a new `deletingExecutions` prop.
- `HistoryExecutionView`: syncs row states from the store poller (`loadedExecutionsSignature`), coalesces overlapping list fetches, and keeps the poller running while viewing history so still-loading rows flip to their final state.
- `general.ts`: disposes background pollers on Vite HMR (`acceptHMRUpdate` + `import.meta.hot`) to avoid zombie intervals in dev. Adapted to core (only `clearHistoricalPollTimer` + the auto-load timer; no recalculation timer in core).

## Adaptations vs source
- Self-referencing imports (`@/…` → `@cornflow-ui/core/…`); added the missing `showSnackbar` import in `general.ts`.
- Reconciled with core's refactored `refreshRunningExecution` and removed the `clearRecalculationPollTimer` reference (recalculation is an enterprise module).
- Updated `general.spec` to the new stop-on-failure contract.

## Verification
- `vue-tsc --noEmit`: **0 errors**
- `vitest run`: **3711 passing** (159 files), 6 skipped
- `vite build`: OK (chunk-size warnings only)
