### PR TITLE
Feature/frontend automation to core

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cornflow-ui/core",
   "private": true,
-  "version": "3.0.3",
+  "version": "3.1.0",
   "type": "module",
   "files": [
     "src"

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -41,6 +41,7 @@ import { useGeneralStore } from '@cornflow-ui/core/stores/general'
 import getAuthService from '@cornflow-ui/core/services/AuthServiceFactory'
 import { registerPremiumModules } from '@cornflow-ui/core/plugins/extensions'
 import type { PremiumModule } from '@cornflow-ui/core/types/extension'
+import { frontendAutomationModule } from '@cornflow-ui/core/modules/frontend-automation'
 
 export interface CreateCornflowAppOptions {
   /** Componente raíz (normalmente App.vue del shell). */
@@ -54,8 +55,13 @@ export interface CreateCornflowAppOptions {
 export async function createCornflowApp(
   options: CreateCornflowAppOptions,
 ): Promise<VueApp> {
-  // Register premium modules first so registerPlugins() can inject their routes/locales.
-  registerPremiumModules(options.premiumModules ?? [])
+  // Register modules first so registerPlugins() can inject their routes/locales.
+  // `frontend-automation` ships in core (master-data config source, always on);
+  // enterprise/consumer premium modules are appended after it.
+  registerPremiumModules([
+    frontendAutomationModule,
+    ...(options.premiumModules ?? []),
+  ])
 
   // Initialize external config first
   await config.initConfig()

--- a/src/modules/frontend-automation/FaRepository.ts
+++ b/src/modules/frontend-automation/FaRepository.ts
@@ -6,11 +6,11 @@ import type {
 import { transformOpenApiToTableConfig } from '@cornflow-ui/core/modules/frontend-automation/openApiTransform'
 
 /**
- * Repositorio de la feature premium FRONTEND-AUTOMATION.
+ * Repository for the FRONTEND-AUTOMATION feature.
  *
- * Carve de `repositories/SchemaRepository.ts`: aquí vive la carga de master-data desde el
- * endpoint `/frontend-automation/` (tablas configurables + secciones/grupos del drawer).
- * El core la consume vía el punto de extensión `loadMasterDataConfig` (no conoce este repo).
+ * Carve of `repositories/SchemaRepository.ts`: this owns loading master-data from the
+ * `/frontend-automation/` endpoint (configurable tables + drawer sections/groups).
+ * The core consumes it via the `loadMasterDataConfig` extension point (it does not know this repo).
  */
 export default class FaRepository {
   /**

--- a/src/modules/frontend-automation/FaRepository.ts
+++ b/src/modules/frontend-automation/FaRepository.ts
@@ -1,0 +1,75 @@
+import client from '@cornflow-ui/core/api/Api'
+import type {
+  AutomationSectionDef,
+  AutomationGroupDef,
+} from '@cornflow-ui/core/types/frontendAutomation'
+import { transformOpenApiToTableConfig } from '@cornflow-ui/core/modules/frontend-automation/openApiTransform'
+
+/**
+ * Repositorio de la feature premium FRONTEND-AUTOMATION.
+ *
+ * Carve de `repositories/SchemaRepository.ts`: aquí vive la carga de master-data desde el
+ * endpoint `/frontend-automation/` (tablas configurables + secciones/grupos del drawer).
+ * El core la consume vía el punto de extensión `loadMasterDataConfig` (no conoce este repo).
+ */
+export default class FaRepository {
+  /**
+   * Get configuration tables (master data), sections and groups from frontend-automation.
+   * Sections and groups are returned sorted by their `order` (integer); they are shown in that order in the drawer.
+   */
+  async getConfigurationTables(): Promise<{
+    config: any
+    sections: AutomationSectionDef[]
+    groups: AutomationGroupDef[]
+  }> {
+    const response = await client.get(`/frontend-automation/`, {}, {}, true)
+
+    if (response.status === 200) {
+      return this.processAutomationResponse(response.content)
+    } else {
+      throw new Error(
+        `Failed to get configuration tables. Status: ${response.status}`,
+      )
+    }
+  }
+
+  /**
+   * Process the frontend-automation response and transform it to our internal format.
+   * Sections and groups are returned sorted by their `order` field.
+   *
+   * @param automationData - The raw response from frontend-automation endpoint
+   * @returns Object with config, sections (sorted by order) and groups (sorted by order)
+   */
+  private processAutomationResponse(automationData: any): {
+    config: any
+    sections: AutomationSectionDef[]
+    groups: AutomationGroupDef[]
+  } {
+    // Validate the response structure
+    if (!automationData?.available_automations) {
+      throw new Error('Invalid automation data structure')
+    }
+
+    const { available_automations, definitions, paths } = automationData
+
+    // Ensure we have the required sections
+    if (!available_automations.tables || !definitions) {
+      throw new Error('Missing required sections in automation data')
+    }
+
+    // Create the structure expected by transformOpenApiToTableConfig (include sections)
+    const processedData = {
+      available_automations: {
+        tables: available_automations.tables,
+        groups: available_automations.groups || {},
+        sections: available_automations.sections || {},
+      },
+      definitions,
+      paths: paths || {},
+    }
+
+    const { config, sections, groups } =
+      transformOpenApiToTableConfig(processedData)
+    return { config, sections, groups }
+  }
+}

--- a/src/modules/frontend-automation/index.ts
+++ b/src/modules/frontend-automation/index.ts
@@ -1,12 +1,12 @@
 /**
- * Módulo premium: FRONTEND-AUTOMATION (master-data dinámico).
+ * Core module: FRONTEND-AUTOMATION (dynamic master-data).
  *
- * Aporta al core la config de master-data (tablas configurables + secciones/grupos del drawer)
- * cargada desde el endpoint `/frontend-automation/`, vía el punto de extensión `loadMasterDataConfig`.
- * El resto de la maquinaria de tablas/secciones (FrontendAutomationService, SectionView, AppDrawer)
- * permanece en el core; este módulo solo es la FUENTE de datos premium.
+ * Provides the core with the master-data config (configurable tables + drawer sections/groups)
+ * loaded from the `/frontend-automation/` endpoint, via the `loadMasterDataConfig` extension point.
+ * The rest of the table/section machinery (FrontendAutomationService, SectionView, AppDrawer)
+ * lives in the core; this module is only the data SOURCE.
  *
- * Contrato: src/types/extension.ts (§3.9) · Diseño: docs/CONTRATO_PUNTOS_EXTENSION.md
+ * Contract: src/types/extension.ts (§3.9).
  */
 import type {
   PremiumModule,

--- a/src/modules/frontend-automation/index.ts
+++ b/src/modules/frontend-automation/index.ts
@@ -1,0 +1,24 @@
+/**
+ * Módulo premium: FRONTEND-AUTOMATION (master-data dinámico).
+ *
+ * Aporta al core la config de master-data (tablas configurables + secciones/grupos del drawer)
+ * cargada desde el endpoint `/frontend-automation/`, vía el punto de extensión `loadMasterDataConfig`.
+ * El resto de la maquinaria de tablas/secciones (FrontendAutomationService, SectionView, AppDrawer)
+ * permanece en el core; este módulo solo es la FUENTE de datos premium.
+ *
+ * Contrato: src/types/extension.ts (§3.9) · Diseño: docs/CONTRATO_PUNTOS_EXTENSION.md
+ */
+import type {
+  PremiumModule,
+  MasterDataConfigContribution,
+} from '@cornflow-ui/core/types/extension'
+import FaRepository from './FaRepository'
+
+export const frontendAutomationModule: PremiumModule = {
+  id: 'frontend-automation',
+
+  loadMasterDataConfig: (): Promise<MasterDataConfigContribution> =>
+    new FaRepository().getConfigurationTables(),
+}
+
+export default frontendAutomationModule

--- a/src/modules/frontend-automation/openApiTransform.ts
+++ b/src/modules/frontend-automation/openApiTransform.ts
@@ -1,14 +1,14 @@
 /**
- * openApiTransform.ts — Transformación OpenAPI → config de tablas (PREMIUM frontend-automation).
+ * openApiTransform.ts — OpenAPI → table config transform (frontend-automation).
  *
- * Antes vivía en `@/utils/schemaUtils` (core), pero solo lo consume la feature premium
- * frontend-automation (vía `FaRepository`): toma el esquema OpenAPI del endpoint
- * `/frontend-automation/` y lo convierte al formato interno de tablas/secciones/grupos.
- * Movido aquí para que el core no exporte lógica específica de premium.
+ * Used only by the frontend-automation feature (via `FaRepository`): it takes the OpenAPI
+ * schema from the `/frontend-automation/` endpoint and converts it to the internal
+ * tables/sections/groups format. Kept in this module (not in `utils/schemaUtils`) so the
+ * core's generic schema utilities don't carry feature-specific logic.
  *
- * Reutiliza helpers genéricos que SÍ se quedan en el core (`@/utils/schemaUtils`):
- * `formatTitle`, `hasValidChoices`, `findFieldWithColumnsRef` (compartidos con la lógica de
- * comparación/diff de master-data del core) y `resolveTitleWithLocale` (`@/utils/i18nUtils`).
+ * Reuses generic helpers that stay in the core (`@cornflow-ui/core/utils/schemaUtils`):
+ * `formatTitle`, `hasValidChoices`, `findFieldWithColumnsRef` (shared with the core's
+ * master-data comparison/diff logic) and `resolveTitleWithLocale` (`@cornflow-ui/core/utils/i18nUtils`).
  */
 import { resolveTitleWithLocale } from '@cornflow-ui/core/utils/i18nUtils'
 import {

--- a/src/modules/frontend-automation/openApiTransform.ts
+++ b/src/modules/frontend-automation/openApiTransform.ts
@@ -1,0 +1,550 @@
+/**
+ * openApiTransform.ts — Transformación OpenAPI → config de tablas (PREMIUM frontend-automation).
+ *
+ * Antes vivía en `@/utils/schemaUtils` (core), pero solo lo consume la feature premium
+ * frontend-automation (vía `FaRepository`): toma el esquema OpenAPI del endpoint
+ * `/frontend-automation/` y lo convierte al formato interno de tablas/secciones/grupos.
+ * Movido aquí para que el core no exporte lógica específica de premium.
+ *
+ * Reutiliza helpers genéricos que SÍ se quedan en el core (`@/utils/schemaUtils`):
+ * `formatTitle`, `hasValidChoices`, `findFieldWithColumnsRef` (compartidos con la lógica de
+ * comparación/diff de master-data del core) y `resolveTitleWithLocale` (`@/utils/i18nUtils`).
+ */
+import { resolveTitleWithLocale } from '@cornflow-ui/core/utils/i18nUtils'
+import {
+  formatTitle,
+  hasValidChoices,
+  findFieldWithColumnsRef,
+} from '@cornflow-ui/core/utils/schemaUtils'
+
+/** Result of transforming OpenAPI automation schema: table config, sections and groups. */
+export interface TransformOpenApiResult {
+  config: any
+  sections: Array<{
+    id: string
+    title: Record<string, string> | string
+    icon?: string
+    order?: number
+  }>
+  groups: Array<{
+    id: string
+    title?: Record<string, string> | string
+    icon?: string
+    order?: number
+  }>
+}
+
+const FORMAT_TO_TYPE: Record<string, string> = {
+  date: 'date',
+  'date-time': 'datetime',
+  time: 'time',
+}
+
+// ─── Main transform ──────────────────────────────────────────────────────────
+
+/** Normalize path for matching (ensure single trailing slash). */
+function normalizePathKey(url: string): string {
+  const s = (url || '').trim()
+  if (!s) return ''
+  return s.endsWith('/') ? s : s + '/'
+}
+
+/**
+ * Get GET method parameters from paths for a given URL (e.g. get_list, or Excel download).
+ * Paths keys may be "/e-planificaciones-atenea/"; url may be "/e-planificaciones-atenea/".
+ */
+function getGetParametersFromPath(
+  paths: Record<string, any>,
+  url: string,
+): any[] | undefined {
+  if (!paths || typeof url !== 'string') return undefined
+  const normalized = normalizePathKey(url)
+  const pathEntry =
+    paths[url] ??
+    paths[normalized] ??
+    paths[url.replace(/\/$/, '')] ??
+    paths[url + '/'] ??
+    paths[
+      Object.keys(paths).find((k) => normalizePathKey(k) === normalized) ?? ''
+    ]
+  const getParams = pathEntry?.get?.parameters
+  return Array.isArray(getParams) ? getParams : undefined
+}
+
+const NON_OPERATION_KEYS = new Set([
+  'group',
+  'title',
+  'icon',
+  'section',
+  'schemas',
+  'model_table_name',
+  '_groupKey',
+  '_originalGroup',
+  '_originalTitle',
+  '_originalSection',
+])
+
+// Transform OpenAPI schema to our internal table configuration format
+export function transformOpenApiToTableConfig(
+  openApiSchema: any,
+  locale: string = 'en',
+): TransformOpenApiResult {
+  const { available_automations, definitions, paths } = openApiSchema
+  const result: any = {}
+
+  const tables = available_automations.tables || available_automations
+  const groupsSource = available_automations.groups || {}
+  const sectionsSource = available_automations.sections || {}
+
+  const sections: Array<{
+    id: string
+    title: Record<string, string> | string
+    icon?: string
+    order?: number
+  }> = Object.entries(sectionsSource)
+    .map(([id, sectionInfo]: [string, any]) => ({
+      id,
+      title: sectionInfo?.title ?? id,
+      icon: sectionInfo?.icon,
+      order:
+        typeof sectionInfo?.order === 'number' ? sectionInfo.order : undefined,
+    }))
+    .sort((a, b) => (a.order ?? 999) - (b.order ?? 999))
+
+  const groups: Array<{
+    id: string
+    title?: Record<string, string> | string
+    icon?: string
+    order?: number
+  }> = Object.entries(groupsSource)
+    .map(([id, groupInfo]: [string, any]) => ({
+      id,
+      title: groupInfo?.title,
+      icon: groupInfo?.icon,
+      order: typeof groupInfo?.order === 'number' ? groupInfo.order : undefined,
+    }))
+    .sort((a, b) => (a.order ?? 999) - (b.order ?? 999))
+
+  Object.entries(tables).forEach(([tableKey, tableInfo]: [string, any]) => {
+    const groupKey = tableInfo.group
+    const groupInfo = groupKey ? groupsSource[groupKey] : null
+
+    const sectionId = tableInfo.section ?? groupInfo?.section ?? null
+
+    const icon = tableInfo.icon || groupInfo?.icon
+
+    result[tableKey] = {
+      group: groupInfo
+        ? resolveTitleWithLocale(groupInfo.title, locale, tableInfo.group)
+        : tableInfo.group,
+      title: resolveTitleWithLocale(tableInfo.title, locale, tableInfo.title),
+      icon,
+      ...(typeof tableInfo.order === 'number' && { order: tableInfo.order }),
+      ...(sectionId !== null && { section: sectionId }),
+      ...(tableInfo.schemas !== undefined && { schemas: tableInfo.schemas }),
+      ...(tableInfo.model_table_name != null &&
+        String(tableInfo.model_table_name).trim() !== '' && {
+          model_table_name: tableInfo.model_table_name,
+        }),
+      ...(groupKey && { _groupKey: groupKey }),
+      _originalGroup: groupInfo ? groupInfo.title : tableInfo.group,
+      _originalTitle: tableInfo.title,
+      ...(sectionId !== null && {
+        _originalSection: sectionsSource[sectionId]?.title ?? sectionId,
+      }),
+    }
+
+    Object.entries(tableInfo).forEach(
+      ([operationKey, operationInfo]: [string, any]) => {
+        if (NON_OPERATION_KEYS.has(operationKey)) return
+        if (
+          !operationInfo ||
+          typeof operationInfo !== 'object' ||
+          !operationInfo.url
+        )
+          return
+
+        // Use parameters from table config if present; otherwise for get_list try to merge from paths
+        let parameters = Array.isArray(operationInfo.parameters)
+          ? operationInfo.parameters
+          : undefined
+        const shouldMergeQueryParamsFromPaths =
+          (operationKey === 'get_list' ||
+            operationKey === 'download_excel_table') &&
+          !parameters &&
+          paths
+        if (shouldMergeQueryParamsFromPaths) {
+          parameters = getGetParametersFromPath(paths, operationInfo.url)
+        }
+
+        const getListUrl =
+          operationKey === 'get_list' ? operationInfo.url : undefined
+        result[tableKey][operationKey] = {
+          url: operationInfo.url,
+          http_method: operationInfo.http_method,
+          request_schema: getRequestSchemaFromDefinitions(
+            operationKey,
+            definitions,
+            tableKey,
+            locale,
+          ),
+          response_schema: getResponseSchemaFromDefinitions(
+            operationKey,
+            tableKey,
+            definitions,
+            locale,
+            paths && getListUrl ? { paths, getListUrl } : undefined,
+          ),
+          ...(Array.isArray(parameters) &&
+            parameters.length > 0 && { parameters }),
+        }
+      },
+    )
+  })
+
+  return { config: result, sections, groups }
+}
+
+// ─── Schema from definitions ─────────────────────────────────────────────────
+
+export function getRequestSchemaFromDefinitions(
+  operationKey: string,
+  definitions: any,
+  tableKey?: string,
+  locale: string = 'en',
+): any {
+  const readOnlyOps = ['get_list', 'get_item', 'delete_item']
+  if (readOnlyOps.includes(operationKey)) return null
+
+  const definitionKey = tableKey
+    ? findDefinitionKeyForTable(tableKey, definitions)
+    : Object.keys(definitions)[0]
+
+  if (!definitionKey || !definitions[definitionKey]) return null
+
+  const schema = convertDefinitionToSchema(definitions[definitionKey], locale)
+  return operationKey === 'post_bulk'
+    ? { type: 'array', items: schema }
+    : schema
+}
+
+/**
+ * Normalize URL for path matching: strip protocol/host, ensure single leading/trailing slash.
+ */
+function normalizePathForMatch(url: string): string {
+  const s = (url || '').trim()
+  if (!s) return ''
+  // Remove protocol and host if present
+  const withoutHost = s.replace(/^https?:\/\/[^/]+/, '')
+  // Trim leading/trailing slashes without a regex (avoids the ReDoS false
+  // positive SonarQube reports on `/\/+$/`; behaviour is identical).
+  let start = 0
+  while (start < withoutHost.length && withoutHost[start] === '/') start++
+  let end = withoutHost.length
+  while (end > start && withoutHost[end - 1] === '/') end--
+  const path = '/' + withoutHost.slice(start, end) + '/'
+  return path.length > 1 && !path.endsWith('/') ? path + '/' : path
+}
+
+/**
+ * Resolve definition key from path GET response (Swagger 2.0: schema.$ref or schema.items.$ref).
+ * Tries exact match first, then normalized match, then match by path suffix, then by tableKey.
+ */
+function getDefinitionKeyFromPathGetResponse(
+  paths: Record<string, any>,
+  getListUrl: string,
+  tableKey?: string,
+): string | null {
+  if (!paths || typeof getListUrl !== 'string') return null
+
+  const normalized = normalizePathKey(normalizePathForMatch(getListUrl))
+  const pathKeys = Object.keys(paths)
+
+  let pathEntry: any =
+    paths[getListUrl] ??
+    paths[normalized] ??
+    paths[getListUrl.replace(/\/$/, '')] ??
+    paths[getListUrl + '/'] ??
+    paths[normalizePathForMatch(getListUrl)]
+
+  if (!pathEntry) {
+    const matchedKey = pathKeys.find(
+      (k) => normalizePathKey(normalizePathForMatch(k)) === normalized,
+    )
+    if (matchedKey) pathEntry = paths[matchedKey]
+  }
+
+  // Fallback: find path whose key ends with the same segment (e.g. /api/v1/areas/ -> /areas/)
+  if (!pathEntry && pathKeys.length > 0) {
+    const segment = normalized.replace(/^\//, '').replace(/\/$/, '')
+    const bySuffix = pathKeys.find((k) => {
+      const n = normalizePathForMatch(k)
+      return segment
+        ? n === normalized ||
+            n.endsWith('/' + segment + '/') ||
+            n.endsWith('/' + segment)
+        : n === normalized
+    })
+    if (bySuffix) pathEntry = paths[bySuffix]
+  }
+
+  // Fallback: find path by tableKey (path key often is kebab-case of table key)
+  if (!pathEntry && tableKey && pathKeys.length > 0) {
+    const tableKeyKebab = tableKey.replaceAll('_', '-').toLowerCase()
+    const tableKeyNorm = tableKey.toLowerCase().replaceAll('-', '_')
+    const byTableKey = pathKeys.find((k) => {
+      const seg = normalizePathForMatch(k).replace(/^\//, '').replace(/\/$/, '')
+      const segNorm = seg.replaceAll('-', '_')
+      return seg === tableKeyKebab || segNorm === tableKeyNorm
+    })
+    if (byTableKey) pathEntry = paths[byTableKey]
+  }
+
+  const getSchema = pathEntry?.get?.responses?.default?.schema
+  if (!getSchema) return null
+  const ref = getSchema.$ref ?? getSchema.items?.$ref
+  if (typeof ref !== 'string' || !ref.startsWith('#/definitions/')) return null
+  return ref.replace('#/definitions/', '')
+}
+
+export function getResponseSchemaFromDefinitions(
+  operationKey: string,
+  tableKey: string,
+  definitions: any,
+  locale: string = 'en',
+  options?: { paths?: Record<string, any>; getListUrl?: string },
+): any {
+  let definitionKey: string | null = null
+
+  // Prefer path-based resolution for get_list: use the path's $ref as source of truth so columns always match the API
+  if (operationKey === 'get_list' && options?.paths && options?.getListUrl) {
+    const pathDefinitionKey = getDefinitionKeyFromPathGetResponse(
+      options.paths,
+      options.getListUrl,
+      tableKey,
+    )
+    if (pathDefinitionKey && definitions[pathDefinitionKey]) {
+      definitionKey = pathDefinitionKey
+    }
+  }
+
+  if (!definitionKey) {
+    definitionKey = findDefinitionKeyForTable(tableKey, definitions)
+  }
+
+  if (!definitionKey || !definitions[definitionKey]) return null
+
+  const schema = convertDefinitionToSchema(definitions[definitionKey], locale)
+
+  if (operationKey === 'get_list') return { type: 'array', items: schema }
+  if (operationKey === 'get_item') return schema
+  return null
+}
+
+// ─── Definition key resolution ───────────────────────────────────────────────
+
+function toPascalCase(str: string): string {
+  return str
+    .split(/[-_]/)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
+    .join('')
+}
+
+function normalizeForComparison(str: string): string {
+  return str.replaceAll(/[-_]/g, '').toLowerCase()
+}
+
+/** Convert PascalCase to snake_case for definition key comparison. */
+function toSnakeCase(str: string): string {
+  return str
+    .replaceAll(/([A-Z])/g, '_$1')
+    .toLowerCase()
+    .replace(/^_/, '')
+}
+
+function findDefinitionKeyForTable(
+  tableKey: string,
+  definitions: any,
+): string | null {
+  const tableDefinitions = Object.keys(definitions).filter(
+    (key) => !key.endsWith('BulkDelete') && !key.endsWith('FromExcel'),
+  )
+
+  const tryMatch = (candidate: string): string | null =>
+    candidate &&
+    definitions[candidate] &&
+    !candidate.endsWith('BulkDelete') &&
+    !candidate.endsWith('FromExcel')
+      ? candidate
+      : null
+
+  // Exact match
+  const exact = tryMatch(tableKey)
+  if (exact) return exact
+
+  // Case-insensitive exact match
+  const ciMatch = tableDefinitions.find(
+    (key) => key.toLowerCase() === tableKey.toLowerCase(),
+  )
+  if (ciMatch) return ciMatch
+
+  // PascalCase conversion
+  const pascalKey = toPascalCase(tableKey)
+  const pascal = tryMatch(pascalKey)
+  if (pascal) return pascal
+
+  // Definition key to snake_case match
+  const normalizedTableKey = tableKey.toLowerCase().replaceAll('-', '_')
+  const snakeMatch = tableDefinitions.find(
+    (key) => toSnakeCase(key) === normalizedTableKey,
+  )
+  if (snakeMatch) return snakeMatch
+
+  // Normalized comparison (remove separators, lowercase)
+  const normalizedCompare = normalizeForComparison(tableKey)
+  const normalizedMatch = tableDefinitions.find(
+    (key) => normalizeForComparison(key) === normalizedCompare,
+  )
+  if (normalizedMatch) return normalizedMatch
+
+  // Simple capitalization
+  const capitalizedKey = tableKey.charAt(0).toUpperCase() + tableKey.slice(1)
+  const capitalized = tryMatch(capitalizedKey)
+  if (capitalized) return capitalized
+
+  // Plural forms
+  const pluralForms = [
+    pascalKey + 's',
+    capitalizedKey + 's',
+    pascalKey.slice(0, -1),
+    capitalizedKey.slice(0, -1),
+  ]
+  for (const form of pluralForms) {
+    const match = tryMatch(form)
+    if (match) return match
+  }
+
+  console.warn(`[schemaUtils] Could not find definition for table: ${tableKey}`)
+  return null
+}
+
+// ─── Definition → schema conversion ─────────────────────────────────────────
+
+function resolveFieldType(prop: any): { type: string; format?: string } {
+  if (prop.type === 'string' && prop.format && FORMAT_TO_TYPE[prop.format]) {
+    return { type: FORMAT_TO_TYPE[prop.format], format: prop.format }
+  }
+  return { type: prop.type }
+}
+
+export function convertDefinitionToSchema(
+  definition: any,
+  locale: string = 'en',
+): any {
+  if (!definition || typeof definition !== 'object') {
+    return { type: 'object', properties: {}, required: [] }
+  }
+  const rawProperties = definition.properties
+  if (!rawProperties || typeof rawProperties !== 'object') {
+    return {
+      type: 'object',
+      properties: {},
+      required: definition.required || [],
+    }
+  }
+  const requiredSet = new Set(
+    Array.isArray(definition.required) ? definition.required : [],
+  )
+  const properties: any = {}
+
+  Object.entries(rawProperties).forEach(([key, prop]: [string, any]) => {
+    const hasColumnsToJoin =
+      prop.columns_to_join && Array.isArray(prop.columns_to_join)
+    const hasJoinFrom = prop.join_from && typeof prop.join_from === 'string'
+    const isMainSelector =
+      hasJoinFrom && isMainSelectorField(key, prop, rawProperties)
+
+    const { type, format } = resolveFieldType(prop)
+
+    properties[key] = {
+      title: resolveTitleWithLocale(prop.title, locale, formatTitle(key)),
+      type,
+      ...(format && { format }),
+      ...(prop.frontendReadOnly && { frontendReadOnly: prop.frontendReadOnly }),
+      required: requiredSet.has(key),
+      ...(hasValidChoices(prop) && { choices: prop.choices }),
+      ...(hasColumnsToJoin && {
+        columnsToJoin: prop.columns_to_join,
+        isForeignKey: true,
+        hidden: true,
+      }),
+      ...(hasJoinFrom && {
+        joinFrom: prop.join_from,
+        isDependentField: true,
+        isMainSelector,
+        foreignKeyField: findForeignKeyFieldForDependent(key, rawProperties),
+        ...(prop.value_none &&
+          typeof prop.value_none === 'object' &&
+          prop.value_none.title != null && {
+            valueNone: { title: prop.value_none.title },
+          }),
+      }),
+      _originalTitle: prop.title,
+    }
+  })
+
+  return {
+    type: 'object',
+    properties,
+    required: definition.required || [],
+    additionalProperties: false,
+    title: resolveTitleWithLocale(definition.title, locale, definition.title),
+    description: resolveTitleWithLocale(
+      definition.description,
+      locale,
+      definition.description,
+    ),
+    _originalTitle: definition.title,
+    _originalDescription: definition.description,
+  }
+}
+
+// ─── Foreign key / dependent field helpers ────────────────────────────────────
+
+/**
+ * Find the FK field that includes `dependentFieldKey` in its `columns_to_join`
+ * (raw OpenAPI format, used during schema conversion).
+ */
+function findForeignKeyFieldForDependent(
+  dependentFieldKey: string,
+  properties: any,
+): string | null {
+  return findFieldWithColumnsRef(
+    dependentFieldKey,
+    properties,
+    'columns_to_join',
+  )
+}
+
+function isMainSelectorField(
+  fieldKey: string,
+  _fieldProp: any,
+  properties: any,
+): boolean {
+  const foreignKeyField = findForeignKeyFieldForDependent(fieldKey, properties)
+  if (!foreignKeyField) return false
+
+  const foreignKeyProp = properties[foreignKeyField]
+  const columnsToJoin = foreignKeyProp?.columns_to_join
+  if (!Array.isArray(columnsToJoin) || !columnsToJoin.includes(fieldKey)) {
+    return false
+  }
+
+  for (const columnKey of columnsToJoin) {
+    const columnProp = properties[columnKey]
+    if (!columnProp) continue
+    if (!columnProp.frontendReadOnly) return columnKey === fieldKey
+  }
+
+  return columnsToJoin[0] === fieldKey
+}

--- a/tests/unit/core/modules/frontend-automation/frontendAutomationModule.spec.ts
+++ b/tests/unit/core/modules/frontend-automation/frontendAutomationModule.spec.ts
@@ -1,0 +1,87 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+
+// Mock the API client used by FaRepository.
+const mockGet = vi.hoisted(() => vi.fn())
+vi.mock('@cornflow-ui/core/api/Api', () => ({
+  default: { get: mockGet },
+}))
+
+// transformOpenApiToTableConfig now lives in the FA module; stub it to a deterministic shape.
+const mockTransform = vi.hoisted(() => vi.fn())
+vi.mock('@cornflow-ui/core/modules/frontend-automation/openApiTransform', () => ({
+  transformOpenApiToTableConfig: mockTransform,
+}))
+
+import frontendAutomationModule from '@cornflow-ui/core/modules/frontend-automation'
+import FaRepository from '@cornflow-ui/core/modules/frontend-automation/FaRepository'
+import type { ExtensionContext } from '@cornflow-ui/core/types/extension'
+
+const ctx = {
+  getConfig: () => ({ getCore: () => ({ parameters: {} }), get: () => undefined }),
+  getRoleNames: () => [],
+  isFeatureEnabled: () => true,
+} as ExtensionContext
+
+describe('frontendAutomationModule (premium descriptor)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('id is "frontend-automation" and exposes loadMasterDataConfig', () => {
+    expect(frontendAutomationModule.id).toBe('frontend-automation')
+    expect(typeof frontendAutomationModule.loadMasterDataConfig).toBe('function')
+  })
+
+  test('loadMasterDataConfig returns the FA endpoint config/sections/groups', async () => {
+    mockGet.mockResolvedValue({
+      status: 200,
+      content: {
+        available_automations: { tables: { t: {} }, groups: {}, sections: {} },
+        definitions: { d: {} },
+        paths: {},
+      },
+    })
+    mockTransform.mockReturnValue({
+      config: { t: { title: 'T' } },
+      sections: [{ key: 's', order: 1 }],
+      groups: [{ key: 'g', order: 1 }],
+    })
+
+    const result = await frontendAutomationModule.loadMasterDataConfig!(ctx)
+
+    expect(mockGet).toHaveBeenCalledWith('/frontend-automation/', {}, {}, true)
+    expect(result.config).toEqual({ t: { title: 'T' } })
+    expect(result.sections).toEqual([{ key: 's', order: 1 }])
+    expect(result.groups).toEqual([{ key: 'g', order: 1 }])
+  })
+})
+
+describe('FaRepository', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('throws on non-200 response', async () => {
+    mockGet.mockResolvedValue({ status: 500, content: {} })
+    await expect(new FaRepository().getConfigurationTables()).rejects.toThrow(
+      /Status: 500/,
+    )
+  })
+
+  test('throws when the automation data structure is invalid', async () => {
+    mockGet.mockResolvedValue({ status: 200, content: {} })
+    await expect(new FaRepository().getConfigurationTables()).rejects.toThrow(
+      'Invalid automation data structure',
+    )
+  })
+
+  test('throws when required sections are missing', async () => {
+    mockGet.mockResolvedValue({
+      status: 200,
+      content: { available_automations: {} },
+    })
+    await expect(new FaRepository().getConfigurationTables()).rejects.toThrow(
+      'Missing required sections in automation data',
+    )
+  })
+})

--- a/tests/unit/core/modules/frontend-automation/openApiTransform.spec.ts
+++ b/tests/unit/core/modules/frontend-automation/openApiTransform.spec.ts
@@ -1,0 +1,168 @@
+import { describe, test, expect } from 'vitest'
+import {
+  transformOpenApiToTableConfig,
+  getRequestSchemaFromDefinitions,
+  getResponseSchemaFromDefinitions,
+  convertDefinitionToSchema,
+} from '@cornflow-ui/core/modules/frontend-automation/openApiTransform'
+
+// ─── convertDefinitionToSchema ───────────────────────────────────────────────
+
+describe('convertDefinitionToSchema', () => {
+  test('returns empty object schema for invalid input', () => {
+    expect(convertDefinitionToSchema(null)).toEqual({
+      type: 'object',
+      properties: {},
+      required: [],
+    })
+  })
+  test('handles definition without properties', () => {
+    const result = convertDefinitionToSchema({ required: ['x'] })
+    expect(result.properties).toEqual({})
+    expect(result.required).toEqual(['x'])
+  })
+  test('converts properties with formats, choices, columns_to_join, join_from', () => {
+    const def = {
+      title: 'My Table',
+      required: ['name'],
+      properties: {
+        name: { type: 'string', title: 'Name' },
+        fecha: { type: 'string', format: 'date' },
+        estado: { type: 'string', choices: ['A', 'B'] },
+        factoria_id: { type: 'integer', columns_to_join: ['factoria'] },
+        factoria: {
+          type: 'string',
+          join_from: 'factorias.nombre',
+          value_none: { title: { en: 'ALL' } },
+        },
+      },
+    }
+    const schema = convertDefinitionToSchema(def, 'en')
+    expect(schema.type).toBe('object')
+    expect(schema.properties.name.required).toBe(true)
+    expect(schema.properties.fecha.type).toBe('date')
+    expect(schema.properties.fecha.format).toBe('date')
+    expect(schema.properties.estado.choices).toEqual(['A', 'B'])
+    expect(schema.properties.factoria_id.isForeignKey).toBe(true)
+    expect(schema.properties.factoria_id.columnsToJoin).toEqual(['factoria'])
+    expect(schema.properties.factoria.isDependentField).toBe(true)
+    expect(schema.properties.factoria.foreignKeyField).toBe('factoria_id')
+    expect(schema.properties.factoria.valueNone).toEqual({ title: { en: 'ALL' } })
+  })
+})
+
+// ─── getRequestSchemaFromDefinitions / getResponseSchemaFromDefinitions ──────
+
+describe('getRequestSchemaFromDefinitions', () => {
+  const definitions = {
+    Areas: { properties: { id: { type: 'integer' }, name: { type: 'string' } } },
+  }
+  test('returns null for read-only operations', () => {
+    expect(getRequestSchemaFromDefinitions('get_list', definitions, 'Areas')).toBeNull()
+    expect(getRequestSchemaFromDefinitions('get_item', definitions, 'Areas')).toBeNull()
+  })
+  test('returns object schema for post_item', () => {
+    const schema = getRequestSchemaFromDefinitions('post_item', definitions, 'Areas')
+    expect(schema.type).toBe('object')
+  })
+  test('wraps in array for post_bulk', () => {
+    const schema = getRequestSchemaFromDefinitions('post_bulk', definitions, 'Areas')
+    expect(schema.type).toBe('array')
+    expect(schema.items.type).toBe('object')
+  })
+  test('returns null when definition missing', () => {
+    expect(getRequestSchemaFromDefinitions('post_item', {}, 'Nope')).toBeNull()
+  })
+})
+
+describe('getResponseSchemaFromDefinitions', () => {
+  const definitions = {
+    Areas: { properties: { id: { type: 'integer' }, name: { type: 'string' } } },
+  }
+  test('get_list returns array wrapper', () => {
+    const schema = getResponseSchemaFromDefinitions('get_list', 'Areas', definitions)
+    expect(schema.type).toBe('array')
+    expect(schema.items.type).toBe('object')
+  })
+  test('get_item returns object schema', () => {
+    const schema = getResponseSchemaFromDefinitions('get_item', 'Areas', definitions)
+    expect(schema.type).toBe('object')
+  })
+  test('other operations return null', () => {
+    expect(getResponseSchemaFromDefinitions('post_item', 'Areas', definitions)).toBeNull()
+  })
+  test('resolves definition via path $ref when provided', () => {
+    const paths = {
+      '/areas/': {
+        get: {
+          responses: { default: { schema: { items: { $ref: '#/definitions/Areas' } } } },
+        },
+      },
+    }
+    const schema = getResponseSchemaFromDefinitions(
+      'get_list',
+      'unknown_table',
+      definitions,
+      'en',
+      { paths, getListUrl: '/areas/' },
+    )
+    expect(schema.type).toBe('array')
+  })
+  test('returns null when definition not found', () => {
+    expect(getResponseSchemaFromDefinitions('get_list', 'Nope', {})).toBeNull()
+  })
+})
+
+// ─── transformOpenApiToTableConfig ───────────────────────────────────────────
+
+describe('transformOpenApiToTableConfig', () => {
+  test('builds config, sections and groups', () => {
+    const openApiSchema = {
+      available_automations: {
+        tables: {
+          areas: {
+            title: { en: 'Areas' },
+            group: 'grp1',
+            order: 1,
+            get_list: { url: '/areas/', http_method: 'GET' },
+            get_item: { url: '/areas/{id}/', http_method: 'GET' },
+            ignored_no_url: { foo: 'bar' },
+          },
+        },
+        groups: { grp1: { title: { en: 'Group One' }, icon: 'mdi-folder', order: 2, section: 'sec1' } },
+        sections: { sec1: { title: { en: 'Section One' }, order: 1 } },
+      },
+      definitions: {
+        Areas: { properties: { id: { type: 'integer' }, name: { type: 'string' } } },
+      },
+      paths: {
+        '/areas/': {
+          get: {
+            parameters: [{ name: 'q', in: 'query' }],
+            responses: { default: { schema: { items: { $ref: '#/definitions/Areas' } } } },
+          },
+        },
+      },
+    }
+    const { config, sections, groups } = transformOpenApiToTableConfig(openApiSchema, 'en')
+    expect(config.areas.title).toBe('Areas')
+    expect(config.areas.group).toBe('Group One')
+    expect(config.areas.section).toBe('sec1')
+    expect(config.areas.get_list.parameters).toEqual([{ name: 'q', in: 'query' }])
+    expect(config.areas.get_list.response_schema.type).toBe('array')
+    expect(config.areas.ignored_no_url).toBeUndefined()
+    expect(sections[0].id).toBe('sec1')
+    expect(groups[0].id).toBe('grp1')
+  })
+  test('handles tables-only available_automations (no groups/sections)', () => {
+    const openApiSchema = {
+      available_automations: {
+        simple: { title: 'Simple', get_list: { url: '/s/', http_method: 'GET' } },
+      },
+      definitions: { Simple: { properties: { id: { type: 'integer' } } } },
+      paths: {},
+    }
+    const { config } = transformOpenApiToTableConfig(openApiSchema)
+    expect(config.simple.title).toBe('Simple')
+  })
+})


### PR DESCRIPTION
## Summary

Moves the **frontend-automation** module from `@cornflow-ui/enterprise` into `@cornflow-ui/core`. Per the product decision (frontend-automation is being moved into the core backend-side too), the frontend logic now ships in core so **every** consumer gets it without depending on enterprise.

The table/section machinery (`FrontendAutomationService`, `SectionView`, `AppDrawer`, types) was already in core; this PR brings the **module** itself — the master-data config source wired through the `loadMasterDataConfig` extension point.

## Changes

- **New:** `src/modules/frontend-automation/` — `index.ts` (the module), `FaRepository.ts` (loads master-data from `/frontend-automation/`), `openApiTransform.ts` (OpenAPI → table config). Imports use core self-referencing paths.
- **`bootstrap.ts`:** `createCornflowApp` now registers `frontendAutomationModule` by default — `registerPremiumModules([frontendAutomationModule, ...(options.premiumModules ?? [])])`. Enterprise/consumer premium modules still append after it.
- **Tests:** moved the module's unit tests into `tests/unit/core/modules/frontend-automation/` (19 tests).
- **Comments** in the moved files translated to English (core convention).
- **Release:** package version bumped to `3.1.0`.

## Coordinated change (enterprise)

`@cornflow-ui/enterprise` drops the module in a matching PR (removed from `src/modules/` and from `enterpriseModules`), and bumps its `@cornflow-ui/core` dependency to the tag that includes this move. Order: merge this PR → tag core → bump enterprise's core dep → verify → tag enterprise.

## Verification

- `vue-tsc --noEmit`: **0 errors**
- `vitest run`: **3730 passing** (161 files), 6 skipped
- `vite build`: OK (chunk-size warnings only)
