### PR TITLE
fix(security): bound email regex quantifiers to avoid ReDoS (S5852)

### DIFF
--- a/src/components/LogInSignUp.vue
+++ b/src/components/LogInSignUp.vue
@@ -262,7 +262,9 @@ export default {
       emailRules: {
         required: (value) => value !== undefined || this.$t('rules.required'),
         format: (value) =>
-          /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value) ||
+          // Bounded quantifiers (local part max 64, domain parts max 63) to avoid
+          // ReDoS super-linear backtracking (SonarQube S5852).
+          /^[^\s@]{1,64}@[^\s@]{1,63}\.[^\s@]{1,63}$/.test(value) ||
           this.$t('rules.valid_email'),
       },
       passwordRules: {

--- a/src/components/roles-management/UserRolesDialog.vue
+++ b/src/components/roles-management/UserRolesDialog.vue
@@ -120,7 +120,9 @@ const firstName = ref('')
 const lastName = ref('')
 const email = ref('')
 
-const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+// Bounded quantifiers (local part max 64, domain parts max 63) to avoid ReDoS
+// super-linear backtracking (SonarQube S5852).
+const EMAIL_RE = /^[^\s@]{1,64}@[^\s@]{1,63}\.[^\s@]{1,63}$/
 const isEmailValid = computed(
   () => email.value.trim() === '' || EMAIL_RE.test(email.value.trim()),
 )


### PR DESCRIPTION
SonarQube flagged two email-validation regexes as security hotspots (typescript:S5852, super-linear backtracking / DoS): LogInSignUp.vue and roles-management/UserRolesDialog.vue. Both used /^[^\s@]+@[^\s@]+\.[^\s@]+$/ where the two unbounded [^\s@]+ around the literal dot can backtrack ambiguously.

Switch to bounded quantifiers /^[^\s@]{1,64}@[^\s@]{1,63}\.[^\s@]{1,63}$/ — the same ReDoS-safe pattern already used in utils/validationRules.ts (local part max 64, domain parts max 63 per RFC). Behaviour unchanged for real email addresses.