### PR TITLE
chore(release): core v3.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cornflow-ui/core",
   "private": true,
-  "version": "3.1.0",
+  "version": "3.2.0",
   "type": "module",
   "files": [
     "src"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=cornflow-ui
 sonar.projectName=Cornflow UI
-sonar.projectVersion=3.1.0
+sonar.projectVersion=3.2.0
 
 # Source code
 sonar.sources=src


### PR DESCRIPTION
## Summary

Release `@cornflow-ui/core` v3.2.0.

Bumps `package.json` (3.1.0 → 3.2.0) and `sonar-project.properties` (projectVersion 3.2.0). Content included since the `v3.1.0` tag:

- **feat:** frontend-automation module now shipped in core (#188)
- **feat:** execution polling hardening (#187)
- **fix(security):** bound email regex quantifiers to avoid ReDoS — S5852 (#190)
- **fix(core-table):** cancel deferred height timer + guard DOM access (#191)
- **fix(ci):** carve-inherited SonarQube key / coverage-threshold cleanup (#189)

After merge, tag `v3.2.0` will be cut from the merge commit so consumers can pin `#v3.2.0`.
